### PR TITLE
Create map matrix compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+test.py

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from map import Map
-from node import Node, NodeState
+from node import Node
 from plotmap import PlotMap
 
 small_map = Map([

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from map import Map, MapCompiler
 from node import Node
-# from plotmap import PlotMap
+from plotmap import PlotMap
 
 # small_map = Map([
 #     [0, 0, 0, 0, 0],
@@ -28,9 +28,9 @@ custom_map.append_walls([(6, 1), (6, 2), (5, 3), (4, 4)])
 custom_map.relocate_start((0,1))
 custom_map.relocate_target((6,12))
 
-# pltmap = PlotMap(large_map)
-# pltmap.plot(plain=True)
-# pltmap.plot()
+pltmap = PlotMap(large_map)
+pltmap.plot(plain=True)
+pltmap.plot()
 
 path = large_map.get_path()
 # print(f'Node: {path.node}')

--- a/main.py
+++ b/main.py
@@ -1,16 +1,16 @@
-from map import Map
+from map import Map, MapCompiler
 from node import Node
-from plotmap import PlotMap
+# from plotmap import PlotMap
 
-small_map = Map([
-    [0, 0, 0, 0, 0],
-    [0, 0, 1, 0, 3],
-    [0, 0, 1, 0, 0],
-    [0, 0, 1, 0, 0],
-    [2, 0, 1, 0, 1],
-])
+# small_map = Map([
+#     [0, 0, 0, 0, 0],
+#     [0, 0, 1, 0, 3],
+#     [0, 0, 1, 0, 0],
+#     [0, 0, 1, 0, 0],
+#     [2, 0, 1, 0, 1],
+# ])
 
-large_map = Map([
+large_map = Map(MapCompiler([
     [0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
     [0,0,0,0,0,0,0,0,0,0,0,0,0,1,0],
     [0,0,0,0,0,0,0,0,0,0,0,0,1,3,0],
@@ -21,18 +21,18 @@ large_map = Map([
     [0,0,1,0,0,1,0,0,1,0,0,0,0,0,0],
     [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
     [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
-])
+]).compile())
 
 custom_map = Map.new(7, 15, (0, 0), (6, 14))
 custom_map.append_walls([(6, 1), (6, 2), (5, 3), (4, 4)])
 custom_map.relocate_start((0,1))
 custom_map.relocate_target((6,12))
 
-pltmap = PlotMap(large_map)
-pltmap.plot(plain=True)
-pltmap.plot()
+# pltmap = PlotMap(large_map)
+# pltmap.plot(plain=True)
+# pltmap.plot()
 
-# path = custom_map.get_path()
+path = large_map.get_path()
 # print(f'Node: {path.node}')
 # print(f'Open: {Node.list_coords(path.open)}')
 # print(f'Closed: {Node.list_coords(path.closed)}')

--- a/map.py
+++ b/map.py
@@ -36,6 +36,13 @@ class MapCompiler:
     
     def has_duplicate_values(self, keys):
         return len(keys) != len(set(keys))
+    
+    def compile(self):
+        compiled_matrix = self.matrix
+        for row_i, row in enumerate(compiled_matrix):
+            for col_i, node in enumerate(row):
+                compiled_matrix[row_i][col_i] = self.keys[node]
+        return compiled_matrix
 
 class Map:
     def __init__(self, matrix):

--- a/map.py
+++ b/map.py
@@ -59,7 +59,7 @@ class Map:
         self.width = len(self.matrix[0])
     
     def __str__(self):
-        return str(self.matrix)
+        return str([[node.type for node in row] for row in self.matrix])
 
     def get_node_of_type(self, type):
         for index, row in enumerate(self.matrix):

--- a/map.py
+++ b/map.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, unique
 from node import Node
 from path import Path
 
@@ -6,6 +6,7 @@ class NodeTypeInitiator:
     def __init__(self, type):
         self.type = type
 
+@unique
 class NodeType(Enum):
     BLANK = NodeTypeInitiator('BLANK')
     WALL = NodeTypeInitiator('WALL')

--- a/map.py
+++ b/map.py
@@ -14,6 +14,8 @@ class NodeType(Enum):
     PATH = NodeTypeInitiator('PATH')
     OPEN = NodeTypeInitiator('OPEN')
     CLOSED = NodeTypeInitiator('CLOSED')
+    
+    FROM_ASSIGN = [BLANK, WALL, START, TARGET]
     FROM_PATH = [PATH, OPEN, CLOSED]
 
 class MapCompiler:

--- a/map.py
+++ b/map.py
@@ -3,8 +3,9 @@ from path import Path
 import node as Node
 
 class NodeTypeInitiator:
-    def __init__(self, type):
+    def __init__(self, type, is_from_init=True):
         self.type = type
+        self.is_from_init = is_from_init
 
     def __str__(self):
         return f'NodeType.{self.type}.value'
@@ -15,12 +16,9 @@ class NodeType(Enum):
     WALL = NodeTypeInitiator('WALL')
     START = NodeTypeInitiator('START')
     TARGET = NodeTypeInitiator('TARGET')
-    PATH = NodeTypeInitiator('PATH')
-    OPEN = NodeTypeInitiator('OPEN')
-    CLOSED = NodeTypeInitiator('CLOSED')
-    
-    FROM_ASSIGN = [BLANK, WALL, START, TARGET]
-    FROM_PATH = [PATH, OPEN, CLOSED]
+    PATH = NodeTypeInitiator('PATH', is_from_init=False)
+    OPEN = NodeTypeInitiator('OPEN', is_from_init=False)
+    CLOSED = NodeTypeInitiator('CLOSED', is_from_init=False)
 
 class MapCompiler:
     def __init__(self, matrix, blank=0, wall=1, start=2, target=3):

--- a/map.py
+++ b/map.py
@@ -11,6 +11,10 @@ class NodeType(Enum):
     WALL = NodeTypeInitiator('WALL')
     START = NodeTypeInitiator('START')
     TARGET = NodeTypeInitiator('TARGET')
+    PATH = NodeTypeInitiator('PATH')
+    OPEN = NodeTypeInitiator('OPEN')
+    CLOSED = NodeTypeInitiator('CLOSED')
+    FROM_PATH = [PATH, OPEN, CLOSED]
 
 class MapCompiler:
     def __init__(self, matrix):

--- a/map.py
+++ b/map.py
@@ -62,7 +62,7 @@ class Map:
     def get_node_of_type(self, type):
         for index, row in enumerate(self.matrix):
             if type in row:
-                return Node(index, row.index(type), None)
+                return Node.Node(index, row.index(type), None)
         raise ValueError(f'Value {type} does not exist in map.')
     
     def get_path(self):
@@ -142,10 +142,10 @@ class Map:
     def relocate_target(self, new_coords: tuple):
         self.target = self.relocate_node(self.target, NodeType.TARGET.value, new_coords)
     
-    def relocate_node(self, node, type, new_coords) -> Node:
+    def relocate_node(self, node, type, new_coords) -> Node.Node:
         prev_row, prev_col = node.get_coords()
         new_row, new_col = new_coords
-        new_node = Node(new_row, new_col, None)
+        new_node = Node.Node(new_row, new_col, None)
 
         if new_node.is_out_of_bounds(self):
             raise ValueError(f'The provided coordinates for the new {type} node are out of bounds.')

--- a/map.py
+++ b/map.py
@@ -32,7 +32,7 @@ class MapCompiler:
         }
     
     def has_duplicate_values(self, keys):
-        return len(keys) == len(set(keys))
+        return len(keys) != len(set(keys))
 
 class Map:
     def __init__(self, matrix):

--- a/map.py
+++ b/map.py
@@ -37,11 +37,17 @@ class MapCompiler:
     def has_duplicate_values(self, keys):
         return len(keys) != len(set(keys))
     
-    def compile(self):
+    def compile(self, force=False):
         compiled_matrix = self.matrix
         for row_i, row in enumerate(compiled_matrix):
             for col_i, node in enumerate(row):
-                compiled_matrix[row_i][col_i] = self.keys[node]
+                try:
+                    compiled_matrix[row_i][col_i] = self.keys[node]
+                except KeyError:
+                    if not force:
+                        raise ValueError('MapCompiler matrix contains uncompilable value.')
+                    compiled_matrix[row_i][col_i] = NodeType.BLANK.value
+
         return compiled_matrix
 
 class Map:

--- a/map.py
+++ b/map.py
@@ -28,6 +28,11 @@ class MapCompiler:
             NodeType.START: start,
             NodeType.TARGET: target,
         }
+        if self.has_duplicate_values(self.keys):
+            raise ValueError('MapCompiler keys cannot have duplicate values.')
+    
+    def has_duplicate_values(self, dict):
+        return len(dict) == len(set(dict.values()))
 
 class Map:
     def __init__(self, matrix):

--- a/map.py
+++ b/map.py
@@ -1,6 +1,6 @@
 from enum import Enum, unique
-from node import Node
 from path import Path
+import node as Node
 
 class NodeTypeInitiator:
     def __init__(self, type):

--- a/map.py
+++ b/map.py
@@ -116,7 +116,7 @@ class Map:
         return self.get_path().get_list()
     
     def new(rows=5, cols=5, start=(0,0), target=(4,4)):
-        new_map = [[0 for _ in range(cols)] for _ in range(rows)]
+        new_map = [[NodeType.BLANK.value for _ in range(cols)] for _ in range(rows)]
 
         start_row, start_col = start
         target_row, target_col = target

--- a/map.py
+++ b/map.py
@@ -6,6 +6,9 @@ class NodeTypeInitiator:
     def __init__(self, type):
         self.type = type
 
+    def __str__(self):
+        return f'NodeType.{self.type}.value'
+
 @unique
 class NodeType(Enum):
     BLANK = NodeTypeInitiator('BLANK')
@@ -25,10 +28,10 @@ class MapCompiler:
         if self.has_duplicate_values([blank, wall, start, target]):
             raise ValueError('MapCompiler keys cannot have duplicate values.')
         self.keys = {
-            blank: NodeType.BLANK,
-            wall: NodeType.WALL,
-            start: NodeType.START,
-            target: NodeType.TARGET,
+            blank: NodeType.BLANK.value,
+            wall: NodeType.WALL.value,
+            start: NodeType.START.value,
+            target: NodeType.TARGET.value,
         }
     
     def has_duplicate_values(self, keys):

--- a/map.py
+++ b/map.py
@@ -1,11 +1,26 @@
-from node import Node, NodeState
+from enum import Enum
+from node import Node
 from path import Path
+
+class NodeTypeInitiator:
+    def __init__(self, type):
+        self.type = type
+
+class NodeType(Enum):
+    BLANK = NodeTypeInitiator('BLANK')
+    WALL = NodeTypeInitiator('WALL')
+    START = NodeTypeInitiator('START')
+    TARGET = NodeTypeInitiator('TARGET')
+
+class MapCompiler:
+    def __init__(self, matrix):
+        self.matrix = matrix
 
 class Map:
     def __init__(self, matrix):
         self.matrix = matrix
-        self.start = self.get_node_with_state(NodeState.START)
-        self.target = self.get_node_with_state(NodeState.TARGET)
+        self.start = self.get_node_with_state(NodeType.START)
+        self.target = self.get_node_with_state(NodeType.TARGET)
         self.height = len(self.matrix)
         self.width = len(self.matrix[0])
     

--- a/map.py
+++ b/map.py
@@ -22,17 +22,17 @@ class NodeType(Enum):
 class MapCompiler:
     def __init__(self, matrix, blank=0, wall=1, start=2, target=3):
         self.matrix = matrix
-        self.keys = {
-            NodeType.BLANK: blank,
-            NodeType.WALL: wall,
-            NodeType.START: start,
-            NodeType.TARGET: target,
-        }
-        if self.has_duplicate_values():
+        if self.has_duplicate_values([blank, wall, start, target]):
             raise ValueError('MapCompiler keys cannot have duplicate values.')
+        self.keys = {
+            blank: NodeType.BLANK,
+            wall: NodeType.WALL,
+            start: NodeType.START,
+            target: NodeType.TARGET,
+        }
     
-    def has_duplicate_values(self):
-        return len(dict) == len(set(self.keys.values()))
+    def has_duplicate_values(self, keys):
+        return len(keys) == len(set(keys))
 
 class Map:
     def __init__(self, matrix):

--- a/map.py
+++ b/map.py
@@ -53,19 +53,19 @@ class MapCompiler:
 class Map:
     def __init__(self, matrix):
         self.matrix = matrix
-        self.start = self.get_node_with_state(NodeType.START)
-        self.target = self.get_node_with_state(NodeType.TARGET)
+        self.start = self.get_node_of_type(NodeType.START.value)
+        self.target = self.get_node_of_type(NodeType.TARGET.value)
         self.height = len(self.matrix)
         self.width = len(self.matrix[0])
     
     def __str__(self):
         return str(self.matrix)
 
-    def get_node_with_state(self, state):
+    def get_node_of_type(self, type):
         for index, row in enumerate(self.matrix):
-            if state.value in row:
-                return Node(index, row.index(state.value), None)
-        raise ValueError(f'Value {state} ({state.value}) does not exist in map.')
+            if type in row:
+                return Node(index, row.index(type), None)
+        raise ValueError(f'Value {type} does not exist in map.')
     
     def get_path(self):
         open = []
@@ -123,8 +123,8 @@ class Map:
         start_row, start_col = start
         target_row, target_col = target
 
-        new_map[start_row][start_col] = NodeState.START.value
-        new_map[target_row][target_col] = NodeState.TARGET.value
+        new_map[start_row][start_col] = NodeType.START.value
+        new_map[target_row][target_col] = NodeType.TARGET.value
 
         return Map(new_map)
     
@@ -136,22 +136,22 @@ class Map:
         
         for node in coords:
             row, col = node
-            self.matrix[row][col] = NodeState.WALL.value
+            self.matrix[row][col] = NodeType.WALL.value
     
     def relocate_start(self, new_coords: tuple):
-        self.start = self.relocate_node(self.start, new_coords, 'START')
+        self.start = self.relocate_node(self.start, NodeType.START.value, new_coords)
     
     def relocate_target(self, new_coords: tuple):
-        self.target = self.relocate_node(self.target, new_coords, 'TARGET')
+        self.target = self.relocate_node(self.target, NodeType.TARGET.value, new_coords)
     
-    def relocate_node(self, node, new_coords, state) -> Node:
+    def relocate_node(self, node, type, new_coords) -> Node:
         prev_row, prev_col = node.get_coords()
         new_row, new_col = new_coords
         new_node = Node(new_row, new_col, None)
 
         if new_node.is_out_of_bounds(self):
-            raise ValueError(f'The provided coordinates for the new {state} node are out of bounds.')
+            raise ValueError(f'The provided coordinates for the new {type} node are out of bounds.')
         
-        self.matrix[prev_row][prev_col] = NodeState.BLANK.value
-        self.matrix[new_row][new_col] = NodeState[state].value
+        self.matrix[prev_row][prev_col] = NodeType.BLANK.value
+        self.matrix[new_row][new_col] = type
         return new_node

--- a/map.py
+++ b/map.py
@@ -19,8 +19,14 @@ class NodeType(Enum):
     FROM_PATH = [PATH, OPEN, CLOSED]
 
 class MapCompiler:
-    def __init__(self, matrix):
+    def __init__(self, matrix, blank=0, wall=1, start=2, target=3):
         self.matrix = matrix
+        self.keys = {
+            NodeType.BLANK: blank,
+            NodeType.WALL: wall,
+            NodeType.START: start,
+            NodeType.TARGET: target,
+        }
 
 class Map:
     def __init__(self, matrix):

--- a/map.py
+++ b/map.py
@@ -28,11 +28,11 @@ class MapCompiler:
             NodeType.START: start,
             NodeType.TARGET: target,
         }
-        if self.has_duplicate_values(self.keys):
+        if self.has_duplicate_values():
             raise ValueError('MapCompiler keys cannot have duplicate values.')
     
-    def has_duplicate_values(self, dict):
-        return len(dict) == len(set(dict.values()))
+    def has_duplicate_values(self):
+        return len(dict) == len(set(self.keys.values()))
 
 class Map:
     def __init__(self, matrix):

--- a/map.py
+++ b/map.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from enum import Enum, unique
 from path import Path
 import node as Node
@@ -36,7 +37,7 @@ class MapCompiler:
         return len(keys) != len(set(keys))
     
     def compile(self, force=False):
-        compiled_matrix = self.matrix
+        compiled_matrix = deepcopy(self.matrix)
         for row_i, row in enumerate(compiled_matrix):
             for col_i, node in enumerate(row):
                 try:
@@ -45,7 +46,6 @@ class MapCompiler:
                     if not force:
                         raise ValueError('MapCompiler matrix contains uncompilable value.')
                     compiled_matrix[row_i][col_i] = NodeType.BLANK.value
-
         return compiled_matrix
 
 class Map:
@@ -109,7 +109,6 @@ class Map:
             hashmap.append(node_total_distance)
             if min(hashmap) == node_total_distance:
                 best_node = node
-        
         return best_node
     
     def get_path_list(self):

--- a/node.py
+++ b/node.py
@@ -1,4 +1,4 @@
-from map import NodeType
+import map as Map
 
 class Node:
     def __init__(self, row, col, parent):
@@ -56,7 +56,7 @@ class Node:
         return self.row + 1 > map.height or self.col + 1 > map.width
     
     def is_wall(self, map):
-        return map.matrix[self.row][self.col] == NodeState.WALL.value
+        return map.matrix[self.row][self.col] == Map.NodeType.WALL.value
     
     def is_in_list(self, list):
         for node in list:

--- a/node.py
+++ b/node.py
@@ -1,13 +1,3 @@
-from enum import Enum
-
-class NodeState(Enum):
-    BLANK = 0
-    WALL = 1
-    START = 2
-    TARGET = 3
-    PATH = 4
-    CLOSED = 5
-    OPEN = 6
 
 class Node:
     def __init__(self, row, col, parent):

--- a/node.py
+++ b/node.py
@@ -1,3 +1,4 @@
+from map import NodeType
 
 class Node:
     def __init__(self, row, col, parent):

--- a/plotmap.py
+++ b/plotmap.py
@@ -25,11 +25,7 @@ class Color:
         return colormap
 
     def get_colors(self, colormap):
-        color_list = [colormap[state] for state in NodeState]
-        largest_colormap_int = max(NodeState, key=lambda k: k.value).value
-        if len(color_list) - 1 < largest_colormap_int:
-            raise ValueError('Invalid NodeState static variables (must be consecutive integers from 0)')
-        return color_list
+        return [colormap[type] for type in colormap]
     
     def get_base_colors(self, colormap):
         return [colormap[state] for state in (nodestate for nodestate in DEFAULT_BASE_COLORMAP)]

--- a/plotmap.py
+++ b/plotmap.py
@@ -14,19 +14,17 @@ DEFAULT_COLORMAP = {
 class Color:
     def __init__(self, colormap):
         colormap = self.fill_missing_keys(colormap)
-        self.colors = self.get_colors(colormap)
-        self.base_colors = self.get_base_colors(colormap)
+        self.colors = colormap
+        self.base_colors = self.get_init_colors(colormap)
     
     def fill_missing_keys(self, colormap):
         for type in NodeType:
-            if not type in colormap:
+            if not type.value in colormap:
                 colormap[type] = DEFAULT_COLORMAP[type]
         return colormap
-
-    def get_colors(self, colormap):
-        return [colormap[type] for type in colormap]
     
-    def get_base_colors(self, colormap):
+    def get_init_colors(self, colormap):
+        return {type: color for (type, color) in colormap.items() if type.is_from_init}
         return [colormap[type] for type in colormap if type.is_from_init]
 
 class PlotMap:
@@ -44,13 +42,14 @@ class PlotMap:
     def show_plot_window(self, matrix, base_only=False):
         plt.xlabel('Col')
         plt.ylabel('Row')
-        plt.imshow(self.get_color_matrix(matrix, self.color.base_colors if base_only else self.color.colors))
+        plt.imshow(self.get_color_matrix(matrix, self.color.colors))
         plt.show()
     
     def get_color_matrix(self, matrix, colormap):
         for row_i, row in enumerate(matrix):
             for col_i, node in enumerate(row):
                 matrix[row_i][col_i] = colormap[node]
+        return matrix
     
     def append_path(self):
         matrix = self.map.matrix

--- a/plotmap.py
+++ b/plotmap.py
@@ -1,6 +1,5 @@
 from map import Map, NodeType
 from matplotlib import pyplot as plt
-from matplotlib import colors
 
 DEFAULT_COLORMAP = {
     NodeType.BLANK: (255, 255, 255), # White
@@ -31,7 +30,7 @@ class Color:
         return [colormap[type] for type in colormap if type.is_from_init]
 
 class PlotMap:
-    def __init__(self, map: Map, colormap=DEFAULT_FULL_COLORMAP):
+    def __init__(self, map: Map, colormap=DEFAULT_COLORMAP):
         self.map = map
         self.color = Color(colormap)
     
@@ -40,7 +39,18 @@ class PlotMap:
             self.show_plot_window(self.map.matrix, base_only=True)
             return
         path_matrix = self.append_path()
-        self.show_plot_window(path_matrix, base_only=False)
+        self.show_plot_window(path_matrix)
+    
+    def show_plot_window(self, matrix, base_only=False):
+        plt.xlabel('Col')
+        plt.ylabel('Row')
+        plt.imshow(self.get_color_matrix(matrix, self.color.base_colors if base_only else self.color.colors))
+        plt.show()
+    
+    def get_color_matrix(self, matrix, colormap):
+        for row_i, row in enumerate(matrix):
+            for col_i, node in enumerate(row):
+                matrix[row_i][col_i] = colormap[node]
     
     def append_path(self):
         matrix = self.map.matrix
@@ -50,29 +60,20 @@ class PlotMap:
         return matrix
     
     def append_open_nodes(self, matrix):
-        self.replace_matrix(matrix, self.map.get_path().open, NodeState.OPEN.value)
+        self.replace_matrix(matrix, self.map.get_path().open, NodeType.OPEN.value)
     
     def append_closed_nodes(self, matrix):
-        self.replace_matrix(matrix, self.map.get_path().closed, NodeState.CLOSED.value)
+        self.replace_matrix(matrix, self.map.get_path().closed, NodeType.CLOSED.value)
     
     def append_path_nodes(self, matrix):
-        self.replace_matrix(matrix, self.map.get_path_list(), NodeState.PATH.value)
+        self.replace_matrix(matrix, self.map.get_path_list(), NodeType.PATH.value)
     
-    def replace_matrix(self, matrix, list, val):
+    def replace_matrix(self, matrix, list, type):
         for node in list:
             if self.is_at_end(node):
                 continue
             row, col = node.get_coords()
-            matrix[row][col] = val
+            matrix[row][col] = type
     
     def is_at_end(self, node):
         return node == self.map.start or node == self.map.target
-    
-    def show_plot_window(self, matrix, base_only=False):
-        plt.xlabel('Col')
-        plt.ylabel('Row')
-        plt.imshow(matrix, cmap=PlotMap.get_colors(self.color.base_colors if base_only else self.color.colors))
-        plt.show()
-    
-    def get_colors(colormap):
-        return colors.ListedColormap(colormap)

--- a/plotmap.py
+++ b/plotmap.py
@@ -2,19 +2,15 @@ from map import Map, NodeType
 from matplotlib import pyplot as plt
 from matplotlib import colors
 
-DEFAULT_BASE_COLORMAP = {
-    NodeState.BLANK: '#fff',
-    NodeState.WALL: '#033',
-    NodeState.START: '#193',
-    NodeState.TARGET: '#c32'
+DEFAULT_COLORMAP = {
+    NodeType.BLANK.value: (255, 255, 255), # White
+    NodeType.WALL.value: (0, 0, 0), # Black
+    NodeType.START.value: (22, 219, 75), # Green
+    NodeType.TARGET.value: (232, 55, 35), # Red
+    NodeType.PATH.value: (255, 205, 54), # Yellow
+    NodeType.CLOSED.value: (58, 145, 214), # Blue
+    NodeType.OPEN.value: (39, 117, 179), # Darker Blue
 }
-
-DEFAULT_FULL_COLORMAP = {
-    NodeState.PATH: '#db1',
-    NodeState.CLOSED: '#27b',
-    NodeState.OPEN: '#1bd'
-}
-DEFAULT_FULL_COLORMAP.update(DEFAULT_BASE_COLORMAP)
 
 class Color:
     def __init__(self, colormap):

--- a/plotmap.py
+++ b/plotmap.py
@@ -3,13 +3,13 @@ from matplotlib import pyplot as plt
 from matplotlib import colors
 
 DEFAULT_COLORMAP = {
-    NodeType.BLANK.value: (255, 255, 255), # White
-    NodeType.WALL.value: (0, 0, 0), # Black
-    NodeType.START.value: (22, 219, 75), # Green
-    NodeType.TARGET.value: (232, 55, 35), # Red
-    NodeType.PATH.value: (255, 205, 54), # Yellow
-    NodeType.CLOSED.value: (58, 145, 214), # Blue
-    NodeType.OPEN.value: (39, 117, 179), # Darker Blue
+    NodeType.BLANK: (255, 255, 255), # White
+    NodeType.WALL: (0, 0, 0), # Black
+    NodeType.START: (22, 219, 75), # Green
+    NodeType.TARGET: (232, 55, 35), # Red
+    NodeType.PATH: (255, 205, 54), # Yellow
+    NodeType.CLOSED: (58, 145, 214), # Blue
+    NodeType.OPEN: (39, 117, 179), # Darker Blue
 }
 
 class Color:

--- a/plotmap.py
+++ b/plotmap.py
@@ -28,7 +28,7 @@ class Color:
         return [colormap[type] for type in colormap]
     
     def get_base_colors(self, colormap):
-        return [colormap[state] for state in (nodestate for nodestate in DEFAULT_BASE_COLORMAP)]
+        return [colormap[type] for type in colormap if type.is_from_init]
 
 class PlotMap:
     def __init__(self, map: Map, colormap=DEFAULT_FULL_COLORMAP):

--- a/plotmap.py
+++ b/plotmap.py
@@ -1,6 +1,4 @@
-from path import Path
-from node import Node, NodeState
-from map import Map
+from map import Map, NodeType
 from matplotlib import pyplot as plt
 from matplotlib import colors
 

--- a/plotmap.py
+++ b/plotmap.py
@@ -2,13 +2,13 @@ from map import Map, NodeType
 from matplotlib import pyplot as plt
 
 DEFAULT_COLORMAP = {
-    NodeType.BLANK: (255, 255, 255), # White
-    NodeType.WALL: (0, 0, 0), # Black
-    NodeType.START: (22, 219, 75), # Green
-    NodeType.TARGET: (232, 55, 35), # Red
-    NodeType.PATH: (255, 205, 54), # Yellow
-    NodeType.CLOSED: (58, 145, 214), # Blue
-    NodeType.OPEN: (39, 117, 179), # Darker Blue
+    NodeType.BLANK.value: (255, 255, 255), # White
+    NodeType.WALL.value: (0, 0, 0), # Black
+    NodeType.START.value: (22, 219, 75), # Green
+    NodeType.TARGET.value: (232, 55, 35), # Red
+    NodeType.PATH.value: (255, 205, 54), # Yellow
+    NodeType.CLOSED.value: (58, 145, 214), # Blue
+    NodeType.OPEN.value: (39, 117, 179), # Darker Blue
 }
 
 class Color:

--- a/plotmap.py
+++ b/plotmap.py
@@ -1,4 +1,5 @@
 from map import Map, NodeType
+from copy import deepcopy
 from matplotlib import pyplot as plt
 
 DEFAULT_COLORMAP = {
@@ -28,22 +29,24 @@ class PlotMap:
     
     def plot(self, plain=False):
         if plain:
-            self.show_plot_window(self.map.matrix, base_only=True)
+            self.show_plot_window(self.map.matrix)
             return
         path_matrix = self.append_path()
         self.show_plot_window(path_matrix)
     
-    def show_plot_window(self, matrix, base_only=False):
+    def show_plot_window(self, matrix):
         plt.xlabel('Col')
         plt.ylabel('Row')
-        plt.imshow(self.get_color_matrix(matrix, self.color.colors))
+        color_matrix = self.get_color_matrix(matrix, self.color.colors)
+        plt.imshow(color_matrix)
         plt.show()
     
     def get_color_matrix(self, matrix, colormap):
+        color_matrix = deepcopy(matrix)
         for row_i, row in enumerate(matrix):
             for col_i, node in enumerate(row):
-                matrix[row_i][col_i] = colormap[node]
-        return matrix
+                color_matrix[row_i][col_i] = colormap[node]
+        return color_matrix
     
     def append_path(self):
         matrix = self.map.matrix

--- a/plotmap.py
+++ b/plotmap.py
@@ -19,9 +19,9 @@ class Color:
         self.base_colors = self.get_base_colors(colormap)
     
     def fill_missing_keys(self, colormap):
-        for state in NodeState:
-            if not state in colormap:
-                colormap[state] = DEFAULT_FULL_COLORMAP[state]
+        for type in NodeType:
+            if not type in colormap:
+                colormap[type] = DEFAULT_COLORMAP[type]
         return colormap
 
     def get_colors(self, colormap):

--- a/plotmap.py
+++ b/plotmap.py
@@ -13,19 +13,13 @@ DEFAULT_COLORMAP = {
 
 class Color:
     def __init__(self, colormap):
-        colormap = self.fill_missing_keys(colormap)
-        self.colors = colormap
-        self.base_colors = self.get_init_colors(colormap)
+        self.colors = self.fill_missing_keys(colormap)
     
     def fill_missing_keys(self, colormap):
         for type in NodeType:
             if not type.value in colormap:
                 colormap[type] = DEFAULT_COLORMAP[type]
         return colormap
-    
-    def get_init_colors(self, colormap):
-        return {type: color for (type, color) in colormap.items() if type.is_from_init}
-        return [colormap[type] for type in colormap if type.is_from_init]
 
 class PlotMap:
     def __init__(self, map: Map, colormap=DEFAULT_COLORMAP):

--- a/test.py
+++ b/test.py
@@ -1,9 +1,9 @@
-key1 = 'key1'
-key2 = 'key1'
+from map import MapCompiler as mapc
 
-keys = {
-    key1: 1,
-    key2: 2,
-}
-
-print(len(keys) == len(set(keys)))
+compiled = mapc([
+    [0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 3],
+    [0, 0, 1, 0, 0],
+    [0, 0, 1, 0, 0],
+    [2, 0, 1, 0, 1],
+]).compile()

--- a/test.py
+++ b/test.py
@@ -1,9 +1,0 @@
-from map import MapCompiler as mapc
-
-compiled = mapc([
-    [0, 0, 0, 0, 0],
-    [0, 0, 1, 0, 3],
-    [0, 0, 1, 0, 0],
-    [0, 0, 1, 0, 0],
-    [2, 0, 1, 0, 1],
-]).compile()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,9 @@
+key1 = 'key1'
+key2 = 'key1'
+
+keys = {
+    key1: 1,
+    key2: 2,
+}
+
+print(len(keys) == len(set(keys)))


### PR DESCRIPTION
Matrices featuring integers must be compiled into matrices featuring nodetypes (objects of NodeTypeInitiator) before being interpreted by a map.
Plotmap now compiles nodetype matrices into colormaps (matrices containing tuplets of RGB values) before being used with the Matplotlib library.